### PR TITLE
- config load bug

### DIFF
--- a/autoPortConfigAgent.py
+++ b/autoPortConfigAgent.py
@@ -159,6 +159,7 @@ class InterfaceMonitor(eossdk.AgentHandler, eossdk.IntfHandler, eossdk.MacTableH
         except:
             # we failed loading yaml.  let's try json
             try:
+                fileHandle.seek(0)
                 result = json.load(fileHandle)
             except:
                 pass


### PR DESCRIPTION
failing the yaml load and falling back to the json load requires a seek back to the beginning of the filehandle for proper operation

Signed-off-by: Patrick Felt <fatpelt@gmail.com>