### PR TITLE
skip applying config if interface is admin down

### DIFF
--- a/autoPortConfigAgent.py
+++ b/autoPortConfigAgent.py
@@ -241,7 +241,8 @@ class InterfaceMonitor(eossdk.AgentHandler, eossdk.IntfHandler, eossdk.MacTableH
             #   to be a lot of interfaces in the coming up state at the same time
             self.enableInterface(intfStr, mac=True, lldp=True)
 
-        elif operState == eossdk.INTF_OPER_DOWN:
+        # only act if the interface is admin enabled, to avoid overriding "shutdown" command
+        elif operState == eossdk.INTF_OPER_DOWN and self.intfMgr_.admin_enabled(intfId):
             # set the default and remove this interface from the list.  if it's the last one,
             #  turn off mac table monitoring.  remove will except... is this better than a try
             #  block?


### PR DESCRIPTION
Since configuring `shutdown` on the interface brings the operational status down, applying a new config for the default linkdown state will immediately override the `shutdown` configuration and bring the port back up.  

This PR changes the behavior so configs are not applied on interfaces that are admin down.

Credit to Edmund for this elegant solution.