### PR TITLE
add LLDP system name partial matching

### DIFF
--- a/autoPortConfigAgent.json.example
+++ b/autoPortConfigAgent.json.example
@@ -57,6 +57,26 @@
     },
     {
       "config": {
+        "name": "a set of lldp capabilities and a specific system name substring",
+        "lldp": {
+          "caps": [
+            "isBridge",
+            "isAP",
+            "isRouter"
+          ],
+          "names": [
+            "xyz123"
+          ]
+        },
+        "states": {
+          "linkup": [
+            "description LLDPnameAndCapabilities"
+          ]
+        }
+      }
+    },
+    {
+      "config": {
         "name": "a set of lldp options and a specific mac or oui",
         "lldp": {
           "caps": [

--- a/autoPortConfigAgent.yml.example
+++ b/autoPortConfigAgent.yml.example
@@ -34,6 +34,18 @@ configs:
       - isBridge
       - isAP
       - isRouter
+      names:
+      - xyz123
+    name: a set of lldp capabilities and a specific system name substring
+    states:
+      linkup:
+      - description LLDPnameAndCapabilities
+- config:
+    lldp:
+      caps:
+      - isBridge
+      - isAP
+      - isRouter
       macs:
       - aabb.ccdd.eeff
     name: a set of lldp options and a specific mac or oui


### PR DESCRIPTION
We can match on a substring of the LLDP system description.  This PR adds the same ability for LLDP system name.

Includes additional example configs.